### PR TITLE
feat: add baidu-cloud-bos skill

### DIFF
--- a/skills/baidu-cloud-bos/SKILL.md
+++ b/skills/baidu-cloud-bos/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: baidu-cloud-bos
+description: >
+  百度智能云对象存储（BOS）集成技能。当用户需要上传、下载、删除或复制 BOS 文件，
+  列出文件列表或 Bucket，获取签名 URL，处理图片（亮度、对比度、模糊、旋转、裁剪、水印等），
+  或递归同步本地目录与 BOS 时使用此技能。
+trigger_keywords: 上传到 BOS、从 BOS 下载、BOS 文件管理、百度云存储、对象存储、bcecmd、同步目录、生成签名链接、BOS 图片处理。
+---
+
+# 百度智能云 BOS 技能
+
+通过 Node.js SDK 脚本 + bcecmd 工具管理百度智能云对象存储（BOS）。
+
+## 首次使用 — 自动设置
+
+当用户首次要求操作 BOS 时，按以下流程操作：
+
+### 步骤 1：检查当前状态
+
+```bash
+{baseDir}/scripts/setup.sh --check-only
+```
+
+如果输出显示一切 OK（SDK 已安装、凭证已配置），跳到「执行策略」。
+
+### 步骤 2：如果未配置，引导用户提供凭证
+
+告诉用户：
+> 我需要你的百度智能云凭证来连接 BOS 存储服务。请提供：
+> 1. **AccessKeyId** — 百度云 AK
+> 2. **SecretAccessKey** — 百度云 SK
+> 3. **Endpoint** — BOS 服务端点（如 `bj.bcebos.com`、`gz.bcebos.com`、`su.bcebos.com`）
+> 4. **Bucket** — 存储桶名称（如 `my-bucket`）
+> 5. **StsToken**（可选） — 临时安全凭证的 SessionToken
+>
+> 你可以在 [百度智能云控制台 > 安全认证 > Access Key](https://console.bce.baidu.com/iam/#/iam/accesslist) 获取密钥，
+> 在 [BOS 控制台](https://console.bce.baidu.com/bos/) 查看存储桶信息。
+>
+**Endpoint 对照表**：
+
+| 区域 | Endpoint |
+|------|----------|
+| 北京 | `bj.bcebos.com` |
+| 广州 | `gz.bcebos.com` |
+| 苏州 | `su.bcebos.com` |
+| 保定 | `bd.bcebos.com` |
+| 香港 | `hkg.bcebos.com` |
+
+### 步骤 3：用户提供凭证后，运行自动设置
+
+```bash
+{baseDir}/scripts/setup.sh --ak "<AccessKeyId>" --sk "<SecretAccessKey>" --endpoint "<Endpoint>" --bucket "<Bucket>"
+```
+
+脚本会自动：
+- 检查并安装 `@baiducloud/sdk`（Node.js SDK）
+- 检查 bcecmd 是否已安装
+- 将凭证持久化到 `~/.config/openclaw/baidu-cloud-bos/credentials.json`（权限 600）
+- 将凭证导出到当前 session 环境变量
+- 配置 bcecmd（如已安装）
+- 验证 BOS 连接
+
+凭证读取优先级：**环境变量 > credentials.json 配置文件**。后续新 session 无需重新配置。
+
+## 执行策略
+
+两种方式按优先级降级，确保操作始终可完成：
+
+1. **方式一：Node.js SDK 脚本**（优先） — 通过 `scripts/bos_node.mjs` 执行存储操作
+2. **方式二：bcecmd 命令行** — 通过 shell 命令执行存储操作，支持目录同步
+
+```
+Node.js + @baiducloud/sdk 可用？
+  ├─ 是 → 使用方式一（单文件操作，JSON 输出，适合程序化处理）
+  └─ 否 → bcecmd 可用？（which bcecmd）
+            ├─ 是 → 使用方式二（全功能，含目录同步）
+            └─ 否 → 运行 setup.sh 安装
+```
+
+**判断方式一**：`node -e "require('@baiducloud/sdk')"` 成功则可用。
+**判断方式二**：`which bcecmd` 有输出则可用。
+
+---
+
+## 方式一：Node.js SDK 脚本（优先）
+
+> 官方文档: https://cloud.baidu.com/doc/BOS/s/Djwvyrhiw
+
+当使用方式一时，通过 `scripts/bos_node.mjs` 执行存储操作。凭证读取优先级：环境变量 > `~/.config/openclaw/baidu-cloud-bos/credentials.json`。
+
+支持的凭证来源：
+- **环境变量**（优先）：`BCE_ACCESS_KEY_ID` / `BCE_SECRET_ACCESS_KEY` / `BCE_BOS_ENDPOINT` / `BCE_BOS_BUCKET`（必需），`BCE_STS_TOKEN`（可选，临时凭证）
+- **配置文件**（回退）：`~/.config/openclaw/baidu-cloud-bos/credentials.json`
+
+### 常用命令
+
+> 以下省略 `node {baseDir}/scripts/bos_node.mjs` 前缀。完整格式：`node {baseDir}/scripts/bos_node.mjs <action> [options]`
+
+```bash
+# 上传文件
+upload --file /path/to/file.jpg --key remote/path/file.jpg
+
+# 上传字符串内容
+put-string --content "文本内容" --key remote/file.txt --content-type "text/plain"
+
+# 下载文件
+download --key remote/path/file.jpg --output /path/to/save/file.jpg
+
+# 列出文件
+list --prefix "images/" --max-keys 100
+
+# 获取签名 URL
+sign-url --key remote/path/file.jpg --expires 3600
+
+# 图片处理：亮度调整（-100 到 100）
+sign-url --key remote/path/image.jpg --bright -5
+
+# 图片处理：对比度调整（-100 到 100）
+sign-url --key remote/path/image.jpg --contrast -30
+
+# 图片处理：模糊（半径,标准差，各 1-50）
+sign-url --key remote/path/image.jpg --blur 2,50
+
+# 图片处理：旋转（-360 到 360，正数顺时针）
+sign-url --key remote/path/image.jpg --rotate 90
+
+# 图片处理：按 EXIF 自适应旋转
+sign-url --key remote/path/image.jpg --auto-orient 1
+
+# 图片处理：多操作链式（便捷 flag 可组合）
+sign-url --key remote/path/image.jpg --bright 10 --contrast 20
+
+# 图片处理：多参数操作用 --process 直传（缩放、裁剪、水印等）
+sign-url --key remote/path/image.jpg --process "image/resize,m_lfit,w_800"
+sign-url --key remote/path/image.jpg --process "image/crop,x_10,y_10,w_200,h_200"
+sign-url --key remote/path/image.jpg --process "image/circle,r_100"
+sign-url --key remote/path/image.jpg --process "image/rounded-corners,r_50"
+sign-url --key remote/path/image.jpg --process "image/quality,q_80"
+sign-url --key remote/path/image.jpg --process "image/watermark,text_aGVsbG8=,g_9"
+sign-url --key remote/path/image.jpg --process "image/bright,b_10/resize,m_lfit,w_800"
+
+# 获取图片详细信息（宽高、格式、色彩深度、透明通道等）
+# 注意：sign-url 只生成 URL，需配合 curl 获取结果
+sign-url --key remote/path/image.jpg --process "image/info"
+# curl -s "$(上述命令输出的 url)"
+
+# resize 模式：lfit=等比缩小至框内，mfit=等比放大至框外，fill=填充裁剪，pad=填充空白，fixed=强制宽高
+# 水印 text 参数需 URL-safe Base64 编码：标准 base64 后将 + → -，/ → _，去掉尾部 =
+
+# 查看文件信息（HEAD）
+head --key remote/path/file.jpg
+
+# 删除文件
+delete --key remote/path/file.jpg
+
+# 复制文件（同桶或跨桶）
+copy --source-bucket <bucket> --source-key <key> --key <dest-key>
+
+# 列出所有 Bucket
+list-buckets
+```
+
+所有命令输出 JSON 格式，`success: true` 表示成功，退出码 0。
+
+### 限制
+
+仅支持单文件操作，**不支持**目录递归上传/下载/同步（请用方式二 bcecmd）。图片处理为方式一独有功能。
+
+---
+
+## 方式二：bcecmd 命令行
+
+> 官方文档: https://cloud.baidu.com/doc/BOS/s/kmcn3zrup
+
+当方式一不可用时使用。bcecmd 是百度云官方命令行工具，支持目录同步等高级功能。
+
+### 首次配置
+
+```bash
+bcecmd --conf-path ~/.bcecmd configure \
+  --access-key <AK> \
+  --secret-key <SK> \
+  --domain <Endpoint>
+```
+
+配置文件保存在 `~/.bcecmd/credentials` 和 `~/.bcecmd/config`。
+
+### 常用命令
+
+```bash
+# 上传文件
+bcecmd bos cp /path/to/file.jpg bos:/<bucket>/remote/path/file.jpg
+
+# 上传目录（递归）
+bcecmd bos cp /path/to/folder/ bos:/<bucket>/remote/folder/ --recursive
+
+# 下载文件
+bcecmd bos cp bos:/<bucket>/remote/path/file.jpg /path/to/save/file.jpg
+
+# 下载目录（递归）
+bcecmd bos cp bos:/<bucket>/remote/folder/ /path/to/save/ --recursive
+
+# 列出文件
+bcecmd bos ls bos:/<bucket>/images/
+
+# 删除文件
+bcecmd bos rm bos:/<bucket>/remote/path/file.jpg
+
+# 递归删除目录
+bcecmd bos rm bos:/<bucket>/remote/folder/ --recursive --yes
+
+# 同步本地目录到 BOS
+bcecmd bos sync /path/to/local/ bos:/<bucket>/remote/ --delete
+
+# 同步 BOS 目录到本地
+bcecmd bos sync bos:/<bucket>/remote/ /path/to/local/ --delete
+
+# 查看文件元信息
+bcecmd bos head bos:/<bucket>/remote/path/file.jpg
+
+# 获取签名 URL（默认 1800 秒，-e 后直接跟秒数无空格；-e-1 为永久有效）
+bcecmd bos gen_signed_url bos:/<bucket>/remote/path/file.jpg -e3600
+bcecmd bos gen_signed_url bos:/<bucket>/remote/path/file.jpg -e-1
+
+# 列出所有 Bucket
+bcecmd bos ls
+
+# 创建 Bucket
+bcecmd bos mb bos:/<bucket>
+
+# 删除 Bucket（必须为空）
+bcecmd bos rb bos:/<bucket>
+
+# 常用全局参数
+# --exclude <PATTERN>  排除匹配的文件（支持上传/下载/同步）
+# --include <PATTERN>  仅包含匹配的文件
+# --conf-path <PATH>   指定配置目录（默认 ~/.bcecmd）
+# 示例：同步时排除日志文件
+bcecmd bos sync /path/to/local/ bos:/<bucket>/remote/ --delete --exclude "*.log"
+```
+
+### 优势
+
+- **目录同步**：`bcecmd bos sync` 支持增量同步、`--delete` 删除远端多余文件
+- **递归操作**：`--recursive` 支持目录级别的上传/下载/删除
+- **大文件**：自动分片上传
+- **Bucket 管理**：创建/删除 Bucket
+
+---
+
+## 功能对照表
+
+| 功能 | 方式一 Node.js SDK | 方式二 bcecmd |
+|------|:-:|:-:|
+| 上传文件 | ✅ | ✅ |
+| 上传字符串/内容 | ✅ | ❌ |
+| 下载文件 | ✅ | ✅ |
+| 列出文件 | ✅ | ✅ |
+| 获取签名 URL | ✅ | ✅ |
+| 图片处理（签名 URL） | ✅ | ❌ |
+| 删除文件 | ✅ | ✅ |
+| 查看文件信息 | ✅ | ✅ |
+| 复制文件 | ✅ | ✅（cp 命令） |
+| 递归上传/下载目录 | ❌ | ✅ |
+| 目录同步（增量） | ❌ | ✅ |
+| Bucket 管理 | ✅（list） | ✅（创建/删除/列表） |
+| JSON 结构化输出 | ✅ | ❌ |
+
+## 使用规范
+
+1. **首次使用先运行** `{baseDir}/scripts/setup.sh --check-only` 检查环境
+2. **凭证不明文展示**：引导用户自行通过 setup.sh 或编辑配置文件设置
+3. **所有文件路径**（`--key`/BOS 路径）为存储桶内的相对路径，如 `images/photo.jpg`
+4. **bcecmd 路径格式**：`bos:/<bucket>/path/to/file`，注意 `bos:/` 前缀
+5. **上传后主动获取链接**：上传完成后调用 `sign-url`（方式一）或 `gen_signed_url`（方式二）返回访问链接
+6. **错误处理**：调用失败时先用 `setup.sh --check-only` 诊断环境问题
+7. **大批量操作优先用 bcecmd**：目录同步、批量上传等场景推荐方式二
+8. **方式一脚本源码**见 `scripts/bos_node.mjs`
+9. **API 参考文档**见 `references/api_reference.md`

--- a/skills/baidu-cloud-bos/references/api_reference.md
+++ b/skills/baidu-cloud-bos/references/api_reference.md
@@ -1,0 +1,209 @@
+# 百度智能云 BOS 操作参考
+
+本文档记录两种操作方式的详细参数定义，供执行操作时查阅。
+
+**环境设置**：首次使用请运行 `scripts/setup.sh`，详见 `SKILL.md` 首次使用章节。
+
+**官方文档链接：**
+- BOS Node.js SDK: https://cloud.baidu.com/doc/BOS/s/Djwvyrhiw
+- bcecmd 工具: https://cloud.baidu.com/doc/BOS/s/kmcn3zrup
+
+---
+
+## 方式一：scripts/bos_node.mjs 命令参考
+
+脚本位于 `scripts/bos_node.mjs`，依赖 `@baiducloud/sdk`（`npm install @baiducloud/sdk`）。
+所有凭证通过环境变量读取。输出 JSON 格式。
+
+### 环境变量
+
+| 变量 | 必需 | 说明 |
+|------|:----:|------|
+| `BCE_ACCESS_KEY_ID` | ✅ | 百度云 Access Key ID |
+| `BCE_SECRET_ACCESS_KEY` | ✅ | 百度云 Secret Access Key |
+| `BCE_BOS_ENDPOINT` | ✅ | BOS 服务端点（如 `bj.bcebos.com`） |
+| `BCE_BOS_BUCKET` | ✅ | 存储桶名称 |
+| `BCE_STS_TOKEN` | ❌ | 临时安全凭证 SessionToken |
+
+### 可用操作
+
+| 操作 | 命令 | 说明 |
+|------|------|------|
+| upload | `node bos_node.mjs upload --file <path> --key <key>` | 上传本地文件 |
+| put-string | `node bos_node.mjs put-string --content <text> --key <key> [--content-type <mime>]` | 上传字符串内容 |
+| download | `node bos_node.mjs download --key <key> --output <path>` | 下载文件到本地 |
+| list | `node bos_node.mjs list [--prefix <prefix>] [--max-keys <n>] [--marker <m>]` | 列出文件 |
+| sign-url | `node bos_node.mjs sign-url --key <key> [--expires <s>] [--bright <n>] [--contrast <n>] [--blur <r,s>] [--rotate <a>] [--auto-orient <o>] [--process <str>]` | 获取签名下载链接（可选图片处理） |
+| head | `node bos_node.mjs head --key <key>` | 查看文件元信息 |
+| delete | `node bos_node.mjs delete --key <key>` | 删除文件 |
+| copy | `node bos_node.mjs copy --source-key <key> --key <dest-key> [--source-bucket <bucket>]` | 复制文件 |
+| list-buckets | `node bos_node.mjs list-buckets` | 列出所有 Bucket |
+
+### 操作详细参数
+
+#### upload
+上传本地文件到存储桶。
+- `--file` (string, **必需**): 本地文件路径
+- `--key` (string, 可选): 存储桶中的目标路径，默认取文件名
+
+#### put-string
+上传字符串内容到存储桶。
+- `--content` (string, **必需**): 要上传的字符串内容
+- `--key` (string, **必需**): 存储桶中的目标路径
+- `--content-type` (string, 可选): MIME 类型，默认 `text/plain`
+
+#### download
+下载存储桶中的文件到本地。
+- `--key` (string, **必需**): 文件在存储桶中的路径
+- `--output` (string, 可选): 本地保存路径，默认取文件名
+
+#### list
+列出存储桶中的文件。
+- `--prefix` (string, 可选): 路径前缀过滤
+- `--max-keys` (number, 可选): 最大返回数量，默认 100
+- `--marker` (string, 可选): 分页标记，用于获取下一页
+
+#### sign-url
+获取文件的预签名下载链接，可选图片处理。
+- `--key` (string, **必需**): 文件在存储桶中的路径
+- `--expires` (number, 可选): 链接有效期（秒），默认 3600
+- `--process` (string, 可选): BOS 图片处理指令，格式 `image/<op>,<p>_<v>[/<op2>,...]`，与便捷 flag 同时使用时优先
+- `--bright` (number, 可选): 亮度调整，范围 -100 到 100（负值变暗，正值变亮）
+- `--contrast` (number, 可选): 对比度调整，范围 -100 到 100（负值降低，正值提高）
+- `--blur` (string, 可选): 模糊，格式 `<r>,<s>`，r 为半径（1-50），s 为标准差（1-50），如 `2,50`
+- `--rotate` (number, 可选): 旋转角度，范围 -360 到 360（正数顺时针，负数逆时针）
+- `--auto-orient` (number, 可选): 自适应旋转，0=不旋转，1=按 EXIF 旋转
+
+#### head
+获取文件的元信息。
+- `--key` (string, **必需**): 文件在存储桶中的路径
+
+#### delete
+删除存储桶中的文件。
+- `--key` (string, **必需**): 文件在存储桶中的路径
+
+#### copy
+复制文件（同桶或跨桶）。
+- `--source-key` (string, **必需**): 源文件路径
+- `--key` (string, **必需**): 目标文件路径
+- `--source-bucket` (string, 可选): 源 Bucket，默认当前 Bucket
+
+#### list-buckets
+列出账号下的所有 Bucket。
+- 无参数
+
+### 返回格式
+
+成功时 `success: true`，退出码 0；失败时 `success: false`，退出码 1。
+
+### 图片处理操作参考
+
+通过 `sign-url` 的 `--process` 或便捷 flag 实现，格式：`image/<操作>,<参数>_<值>[/<操作2>,...]`
+
+#### 亮度（bright）
+
+| flag | 参数 | 类型 | 范围 | 说明 |
+|------|------|------|------|------|
+| `--bright <n>` | `b` | integer | -100 ~ 100 | 负值变暗，正值变亮，0 不变 |
+
+#### 对比度（contrast）
+
+| flag | 参数 | 类型 | 范围 | 说明 |
+|------|------|------|------|------|
+| `--contrast <n>` | `c` | integer | -100 ~ 100 | 负值降低，正值提高，0 不变 |
+
+#### 模糊（blur）
+
+| flag | 参数 | 类型 | 范围 | 说明 |
+|------|------|------|------|------|
+| `--blur <r,s>` | `r` | integer | 1 ~ 50 | 模糊半径 |
+|  | `s` | integer | 1 ~ 50 | 模糊标准差 |
+
+示例：`--blur 2,50`（等价于 `--process "image/blur,r_2,s_50"`）
+
+#### 旋转（rotate）
+
+| flag | 参数 | 类型 | 范围 | 说明 |
+|------|------|------|------|------|
+| `--rotate <a>` | `a` | integer | -360 ~ 360 | 正数顺时针，负数逆时针 |
+
+#### 自适应旋转（auto-orient）
+
+| flag | 参数 | 类型 | 取值 | 说明 |
+|------|------|------|------|------|
+| `--auto-orient <o>` | `o` | integer | 0 / 1 | 0=不旋转，1=按 EXIF 自适应旋转 |
+
+#### 多参数操作（通过 --process 直传）
+
+| 操作 | process 格式 | 示例 |
+|------|-------------|------|
+| 图像缩放（resize） | `image/resize,m_<mode>,w_<w>,h_<h>` | `--process "image/resize,m_lfit,w_200,h_100"` |
+| 普通裁剪（crop） | `image/crop,x_<x>,y_<y>,w_<w>,h_<h>` | `--process "image/crop,x_10,y_10,w_200,h_200"` |
+| 内切圆裁剪（circle） | `image/circle,r_<r>` | `--process "image/circle,r_100"` |
+| 圆角矩形裁剪（rounded-corners） | `image/rounded-corners,r_<r>` | `--process "image/rounded-corners,r_50"` |
+| 质量变换（quality） | `image/quality,q_<q>` 或 `image/quality,Q_<Q>` | `--process "image/quality,q_80"` |
+| 文字水印（watermark） | `image/watermark,text_<urlsafe-base64>,...` | `--process "image/watermark,text_aGVsbG8=,g_9"` |
+| 图片水印（watermark） | `image/watermark,image_<urlsafe-base64>,...` | `--process "image/watermark,image_<base64>,g_9"` |
+| 获取图片信息（info） | `image/info` | `--process "image/info"` |
+
+resize 模式说明：`lfit`（等比缩小至框内）、`mfit`（等比放大至框外）、`fill`（填充裁剪）、`pad`（填充空白）、`fixed`（强制宽高）
+
+文字水印 text 参数需 URL-safe Base64 编码：标准 base64 后将 `+` → `-`，`/` → `_`，去掉尾部 `=`
+
+---
+
+## 方式二：bcecmd 命令参考
+
+依赖百度云 bcecmd 工具，需手动安装。
+
+安装参考: https://cloud.baidu.com/doc/BOS/s/kmcn3zrup
+
+### 首次配置
+
+```bash
+bcecmd --conf-path ~/.bcecmd configure \
+  --access-key <AK> \
+  --secret-key <SK> \
+  --domain <Endpoint>
+```
+
+### 常用命令
+
+| 操作 | 命令 | 说明 |
+|------|------|------|
+| 上传文件 | `bcecmd bos cp <localpath> bos:/<bucket>/<bospath>` | 上传单个文件 |
+| 递归上传目录 | `bcecmd bos cp <localdir> bos:/<bucket>/<bosdir>/ --recursive` | 上传整个目录 |
+| 下载文件 | `bcecmd bos cp bos:/<bucket>/<bospath> <localpath>` | 下载单个文件 |
+| 递归下载目录 | `bcecmd bos cp bos:/<bucket>/<bosdir>/ <localdir> --recursive` | 下载整个目录 |
+| 列出文件 | `bcecmd bos ls bos:/<bucket>/[prefix]` | 列出文件 |
+| 删除文件 | `bcecmd bos rm bos:/<bucket>/<bospath>` | 删除单个文件 |
+| 递归删除 | `bcecmd bos rm bos:/<bucket>/<bosdir>/ --recursive --yes` | 强制递归删除 |
+| 同步到 BOS | `bcecmd bos sync <localdir> bos:/<bucket>/<dir>/ [--delete]` | 增量同步本地到远端 |
+| 同步到本地 | `bcecmd bos sync bos:/<bucket>/<dir>/ <localdir> [--delete]` | 增量同步远端到本地 |
+| 文件信息 | `bcecmd bos head bos:/<bucket>/<bospath>` | 查看文件元信息 |
+| 签名 URL | `bcecmd bos gen_signed_url bos:/<bucket>/<bospath> [-e<seconds>]` | 获取签名下载链接 |
+| 列出 Bucket | `bcecmd bos ls` | 列出所有 Bucket |
+| 创建 Bucket | `bcecmd bos mb bos:/<bucket>` | 创建存储桶 |
+| 删除 Bucket | `bcecmd bos rb bos:/<bucket>` | 删除存储桶（必须为空） |
+
+### 全局参数
+
+- `--conf-path <PATH>`：指定配置目录（默认 `~/.bcecmd`）
+- `--recursive` / `-r`：递归操作
+- `--yes` / `-y`：跳过确认
+- `--delete`：同步时删除目标端多余文件
+- `--exclude <PATTERN>`：排除匹配的文件
+- `--include <PATTERN>`：仅包含匹配的文件
+- `-e<seconds>`：`gen_signed_url` 专用，指定 URL 有效期（秒），`-1` 为永久有效，默认 1800 秒；注意 `-e` 与数字之间无空格
+
+---
+
+## BOS Endpoint 对照表
+
+| 区域 | Endpoint | 位置 |
+|------|----------|------|
+| 北京 | `bj.bcebos.com` | 华北 |
+| 广州 | `gz.bcebos.com` | 华南 |
+| 苏州 | `su.bcebos.com` | 华东 |
+| 保定 | `bd.bcebos.com` | 华北 |
+| 香港 | `hkg.bcebos.com` | 港澳台 |

--- a/skills/baidu-cloud-bos/scripts/bos_node.mjs
+++ b/skills/baidu-cloud-bos/scripts/bos_node.mjs
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+/**
+ * 百度智能云 BOS Node.js SDK 操作脚本
+ *
+ * 依赖：npm install @baiducloud/sdk
+ * 凭证读取优先级：
+ *   1. 环境变量：BCE_ACCESS_KEY_ID / BCE_SECRET_ACCESS_KEY / BCE_BOS_ENDPOINT / BCE_BOS_BUCKET
+ *   2. 配置文件：~/.config/openclaw/baidu-cloud-bos/credentials.json
+ *   BCE_STS_TOKEN（可选，临时凭证）
+ *
+ * 用法：node bos_node.mjs <action> [--option value ...]
+ */
+
+import { createRequire } from 'module';
+import { createReadStream, readFileSync, writeFileSync, existsSync } from 'fs';
+import { basename, resolve, join } from 'path';
+import { homedir } from 'os';
+import { stat } from 'fs/promises';
+
+const require = createRequire(import.meta.url);
+const { BosClient } = require('@baiducloud/sdk');
+
+// 凭证加载：环境变量优先，回退到 ~/.config/openclaw/baidu-cloud-bos/credentials.json
+function loadCredentials() {
+  let ak = process.env.BCE_ACCESS_KEY_ID;
+  let sk = process.env.BCE_SECRET_ACCESS_KEY;
+  let endpoint = process.env.BCE_BOS_ENDPOINT;
+  let bucket = process.env.BCE_BOS_BUCKET;
+  let stsToken = process.env.BCE_STS_TOKEN;
+
+  if (!ak || !sk || !endpoint || !bucket) {
+    const credPath = join(homedir(), '.config', 'openclaw', 'baidu-cloud-bos', 'credentials.json');
+    if (existsSync(credPath)) {
+      try {
+        const cred = JSON.parse(readFileSync(credPath, 'utf-8'));
+        ak = ak || cred.accessKeyId;
+        sk = sk || cred.secretAccessKey;
+        endpoint = endpoint || cred.endpoint;
+        bucket = bucket || cred.bucket;
+        stsToken = stsToken || cred.stsToken;
+      } catch (e) {
+        // credentials.json 解析失败，忽略
+      }
+    }
+  }
+
+  if (!ak || !sk || !endpoint || !bucket) {
+    console.error(JSON.stringify({
+      success: false,
+      error: '缺少凭证。请通过环境变量设置，或运行 setup.sh 将凭证保存到 ~/.config/openclaw/baidu-cloud-bos/credentials.json',
+    }));
+    process.exit(1);
+  }
+
+  return { ak, sk, endpoint, bucket, stsToken };
+}
+
+const { ak: AK, sk: SK, endpoint: ENDPOINT, bucket: BUCKET, stsToken: STS_TOKEN } = loadCredentials();
+
+const config = {
+  credentials: {
+    ak: AK,
+    sk: SK,
+  },
+  endpoint: ENDPOINT.startsWith('http') ? ENDPOINT : `https://${ENDPOINT}`,
+};
+
+if (STS_TOKEN) {
+  config.sessionToken = STS_TOKEN;
+}
+
+const client = new BosClient(config);
+
+// 解析命令行参数
+function parseArgs(args) {
+  const result = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = args[i + 1];
+      if (next && !next.startsWith('--')) {
+        result[key] = next;
+        i++;
+      } else {
+        result[key] = true;
+      }
+    }
+  }
+  return result;
+}
+
+// 输出 JSON 结果
+function output(data) {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+// ========== 图片处理 ==========
+
+// 图片处理操作注册表：key 是 CLI flag 名，value 是验证+构建函数
+// 扩展新操作只需在此添加一个条目
+const IMAGE_OPS = {
+  bright: (value) => {
+    const b = parseInt(value, 10);
+    if (isNaN(b) || b < -100 || b > 100) {
+      throw new Error('--bright 参数范围：-100 到 100');
+    }
+    return `image/bright,b_${b}`;
+  },
+  contrast: (value) => {
+    const c = parseInt(value, 10);
+    if (isNaN(c) || c < -100 || c > 100) throw new Error('--contrast 参数范围：-100 到 100');
+    return `image/contrast,c_${c}`;
+  },
+
+  blur: (value) => {
+    // 接受 "r,s" 格式（如 "2,50"）或单个数字（r=s）
+    const parts = String(value).split(',');
+    const r = parseInt(parts[0], 10);
+    const s = parseInt(parts[1] ?? parts[0], 10);
+    if (isNaN(r) || r < 1 || r > 50) throw new Error('--blur r 参数范围：1 到 50');
+    if (isNaN(s) || s < 1 || s > 50) throw new Error('--blur s 参数范围：1 到 50');
+    return `image/blur,r_${r},s_${s}`;
+  },
+
+  rotate: (value) => {
+    const a = parseInt(value, 10);
+    if (isNaN(a) || a < -360 || a > 360) throw new Error('--rotate 参数范围：-360 到 360');
+    return `image/rotate,a_${a}`;
+  },
+
+  'auto-orient': (value) => {
+    const o = parseInt(value, 10);
+    if (o !== 0 && o !== 1) throw new Error('--auto-orient 参数取值：0 或 1');
+    return `image/auto-orient,o_${o}`;
+  },
+};
+
+/**
+ * 从 CLI opts 构建 x-bce-process 字符串。
+ * --process 直传优先；否则从便捷 flag 构建并链式合并。
+ * 返回 undefined 表示无图片处理。
+ */
+function buildProcessString(opts) {
+  if (opts.process) return opts.process;
+
+  const parts = [];
+  for (const [flag, builder] of Object.entries(IMAGE_OPS)) {
+    if (opts[flag] !== undefined) {
+      parts.push(builder(opts[flag]));
+    }
+  }
+
+  if (parts.length === 0) return undefined;
+
+  // 多操作链式合并：image/bright,b_-5 + image/resize,w_200 → image/bright,b_-5/resize,w_200
+  return parts[0] + parts.slice(1).map(p => '/' + p.replace(/^image\//, '')).join('');
+}
+
+// ========== 操作实现 ==========
+
+async function upload(opts) {
+  const filePath = opts.file;
+  const key = opts.key || basename(filePath);
+
+  if (!filePath) {
+    throw new Error('缺少 --file 参数');
+  }
+  if (!existsSync(filePath)) {
+    throw new Error(`文件不存在：${filePath}`);
+  }
+
+  const fileInfo = await stat(filePath);
+  const buffer = readFileSync(filePath);
+
+  const response = await client.putObject(BUCKET, key, buffer);
+
+  output({
+    success: true,
+    action: 'upload',
+    key,
+    etag: response.body?.eTag || response.http_headers?.etag,
+    size: fileInfo.size,
+    bucket: BUCKET,
+  });
+}
+
+async function putString(opts) {
+  const content = opts.content;
+  const key = opts.key;
+  const contentType = opts['content-type'] || 'text/plain';
+
+  if (!content) {
+    throw new Error('缺少 --content 参数');
+  }
+  if (!key) {
+    throw new Error('缺少 --key 参数');
+  }
+
+  const response = await client.putObjectFromString(BUCKET, key, content, {
+    'Content-Type': contentType,
+  });
+
+  output({
+    success: true,
+    action: 'put-string',
+    key,
+    etag: response.body?.eTag || response.http_headers?.etag,
+    bucket: BUCKET,
+  });
+}
+
+async function download(opts) {
+  const key = opts.key;
+  const outputPath = opts.output || basename(key);
+
+  if (!key) {
+    throw new Error('缺少 --key 参数');
+  }
+
+  const response = await client.getObjectToFile(BUCKET, key, resolve(outputPath));
+
+  output({
+    success: true,
+    action: 'download',
+    key,
+    savedTo: resolve(outputPath),
+    bucket: BUCKET,
+  });
+}
+
+async function list(opts) {
+  const prefix = opts.prefix || '';
+  const maxKeys = parseInt(opts['max-keys'], 10) || 100;
+  const marker = opts.marker || '';
+
+  const options = {};
+  if (prefix) options.prefix = prefix;
+  if (maxKeys) options.maxKeys = maxKeys;
+  if (marker) options.marker = marker;
+
+  const response = await client.listObjects(BUCKET, options);
+  const contents = response.body?.contents || [];
+
+  const files = contents.map(item => ({
+    key: item.key,
+    size: item.size,
+    lastModified: item.lastModified,
+    eTag: item.eTag,
+    storageClass: item.storageClass,
+  }));
+
+  output({
+    success: true,
+    action: 'list',
+    prefix,
+    count: files.length,
+    isTruncated: response.body?.isTruncated || false,
+    nextMarker: response.body?.nextMarker || null,
+    files,
+  });
+}
+
+async function signUrl(opts) {
+  const key = opts.key;
+  const expires = parseInt(opts.expires, 10) || 3600;
+
+  if (!key) {
+    throw new Error('缺少 --key 参数');
+  }
+
+  const processStr = buildProcessString(opts);
+  const params = processStr ? { 'x-bce-process': processStr } : undefined;
+
+  const url = client.generatePresignedUrl(BUCKET, key, 0, expires, undefined, params);
+
+  const result = { success: true, action: 'sign-url', key, expires, url };
+  if (processStr) result.process = processStr;
+
+  output(result);
+}
+
+async function headObject(opts) {
+  const key = opts.key;
+
+  if (!key) {
+    throw new Error('缺少 --key 参数');
+  }
+
+  const response = await client.getObjectMetadata(BUCKET, key);
+  const headers = response.http_headers || {};
+
+  output({
+    success: true,
+    action: 'head',
+    key,
+    contentLength: parseInt(headers['content-length'], 10),
+    contentType: headers['content-type'],
+    eTag: headers.etag,
+    lastModified: headers['last-modified'],
+    storageClass: headers['x-bce-storage-class'] || 'STANDARD',
+    bucket: BUCKET,
+  });
+}
+
+async function deleteObject(opts) {
+  const key = opts.key;
+
+  if (!key) {
+    throw new Error('缺少 --key 参数');
+  }
+
+  await client.deleteObject(BUCKET, key);
+
+  output({
+    success: true,
+    action: 'delete',
+    key,
+    bucket: BUCKET,
+  });
+}
+
+async function copyObject(opts) {
+  const sourceBucket = opts['source-bucket'] || BUCKET;
+  const sourceKey = opts['source-key'];
+  const key = opts.key;
+
+  if (!sourceKey) {
+    throw new Error('缺少 --source-key 参数');
+  }
+  if (!key) {
+    throw new Error('缺少 --key 参数（目标路径）');
+  }
+
+  const response = await client.copyObject(sourceBucket, sourceKey, BUCKET, key);
+
+  output({
+    success: true,
+    action: 'copy',
+    sourceBucket,
+    sourceKey,
+    destBucket: BUCKET,
+    destKey: key,
+    eTag: response.body?.eTag,
+  });
+}
+
+async function listBuckets() {
+  const response = await client.listBuckets();
+  const buckets = (response.body?.buckets || []).map(b => ({
+    name: b.name,
+    location: b.location,
+    creationDate: b.creationDate,
+  }));
+
+  output({
+    success: true,
+    action: 'list-buckets',
+    count: buckets.length,
+    buckets,
+  });
+}
+
+// ========== 主入口 ==========
+
+const args = process.argv.slice(2);
+const action = args[0];
+const opts = parseArgs(args.slice(1));
+
+const actions = {
+  upload,
+  'put-string': putString,
+  download,
+  list,
+  'sign-url': signUrl,
+  head: headObject,
+  delete: deleteObject,
+  copy: copyObject,
+  'list-buckets': listBuckets,
+};
+
+if (!action || !actions[action]) {
+  output({
+    success: false,
+    error: `未知操作：${action || '(空)'}`,
+    availableActions: Object.keys(actions),
+    usage: 'node bos_node.mjs <action> [--option value ...]',
+  });
+  process.exit(1);
+}
+
+try {
+  await actions[action](opts);
+} catch (err) {
+  output({
+    success: false,
+    action,
+    error: err.message || String(err),
+    code: err.code,
+    statusCode: err.status_code,
+  });
+  process.exit(1);
+}

--- a/skills/baidu-cloud-bos/scripts/setup.sh
+++ b/skills/baidu-cloud-bos/scripts/setup.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+# 百度智能云 BOS Skill 自动设置脚本
+# 用法:
+#   setup.sh --check-only                    仅检查环境状态
+#   setup.sh --ak <AK> --sk <SK> --endpoint <ENDPOINT> --bucket <BUCKET>
+
+set -e
+
+# 颜色
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+ok()   { echo -e "${GREEN}✓${NC} $1"; }
+fail() { echo -e "${RED}✗${NC} $1"; }
+warn() { echo -e "${YELLOW}!${NC} $1"; }
+
+# 获取脚本所在目录（skill baseDir）
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BASE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ========== 检查函数 ==========
+
+check_node() {
+  if command -v node &>/dev/null; then
+    ok "Node.js $(node --version)"
+    return 0
+  else
+    fail "Node.js 未安装"
+    return 1
+  fi
+}
+
+check_npm() {
+  if command -v npm &>/dev/null; then
+    ok "npm $(npm --version)"
+    return 0
+  else
+    fail "npm 未安装"
+    return 1
+  fi
+}
+
+check_bos_node_sdk() {
+  if command -v node &>/dev/null && node -e "require('@baiducloud/sdk')" &>/dev/null 2>&1; then
+    ok "@baiducloud/sdk (Node.js SDK) 已安装"
+    return 0
+  else
+    fail "@baiducloud/sdk (Node.js SDK) 未安装"
+    return 1
+  fi
+}
+
+check_bcecmd() {
+  if command -v bcecmd &>/dev/null; then
+    ok "bcecmd 可用"
+    return 0
+  else
+    warn "bcecmd 未安装（可选，安装参考: https://cloud.baidu.com/doc/BOS/s/Ck1rymwdi）"
+    return 1
+  fi
+}
+
+check_env_vars() {
+  local all_set=true
+  for var in BCE_ACCESS_KEY_ID BCE_SECRET_ACCESS_KEY BCE_BOS_ENDPOINT BCE_BOS_BUCKET; do
+    if [ -n "${!var}" ]; then
+      ok "$var 已设置"
+    else
+      fail "$var 未设置"
+      all_set=false
+    fi
+  done
+  $all_set
+}
+
+# ========== 检查模式 ==========
+
+do_check() {
+  echo "=== 百度智能云 BOS Skill 环境检查 ==="
+  echo ""
+  echo "--- 基础环境 ---"
+  check_node || true
+  check_npm || true
+  echo ""
+  echo "--- 方式一: Node.js SDK ---"
+  check_bos_node_sdk || true
+  echo ""
+  echo "--- 方式二: bcecmd ---"
+  check_bcecmd || true
+  echo ""
+  echo "--- 环境变量 ---"
+  check_env_vars || true
+  echo ""
+  echo "--- Skill 文件 ---"
+  [ -f "$BASE_DIR/SKILL.md" ] && ok "SKILL.md" || fail "SKILL.md 不存在"
+  [ -f "$BASE_DIR/scripts/bos_node.mjs" ] && ok "scripts/bos_node.mjs" || fail "scripts/bos_node.mjs 不存在"
+  [ -f "$BASE_DIR/references/api_reference.md" ] && ok "references/api_reference.md" || fail "references/api_reference.md 不存在"
+  echo ""
+}
+
+# ========== 设置模式 ==========
+
+do_setup() {
+  local AK=""
+  local SK=""
+  local ENDPOINT=""
+  local BUCKET=""
+  local STS_TOKEN=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --ak)        AK="$2"; shift 2;;
+      --sk)        SK="$2"; shift 2;;
+      --endpoint)  ENDPOINT="$2"; shift 2;;
+      --bucket)    BUCKET="$2"; shift 2;;
+      --sts-token) STS_TOKEN="$2"; shift 2;;
+      *) shift;;
+    esac
+  done
+
+  if [ -z "$AK" ] || [ -z "$SK" ] || [ -z "$ENDPOINT" ] || [ -z "$BUCKET" ]; then
+    echo "错误: 缺少必需参数"
+    echo "用法: setup.sh --ak <AK> --sk <SK> --endpoint <ENDPOINT> --bucket <BUCKET>"
+    exit 1
+  fi
+
+  # 输入校验：AK/SK 仅允许字母数字，Endpoint 仅允许域名字符，Bucket 仅允许 DNS 字符
+  local SAFE_PATTERN_AKSK='^[A-Za-z0-9/+=]+$'
+  local SAFE_PATTERN_ENDPOINT='^[a-zA-Z0-9._-]+$'
+  local SAFE_PATTERN_BUCKET='^[a-z0-9][a-z0-9.-]*[a-z0-9]$'
+
+  if [[ ! "$AK" =~ $SAFE_PATTERN_AKSK ]]; then
+    echo "错误: AccessKeyId 包含非法字符"; exit 1
+  fi
+  if [[ ! "$SK" =~ $SAFE_PATTERN_AKSK ]]; then
+    echo "错误: SecretAccessKey 包含非法字符"; exit 1
+  fi
+  if [[ ! "$ENDPOINT" =~ $SAFE_PATTERN_ENDPOINT ]]; then
+    echo "错误: Endpoint 包含非法字符"; exit 1
+  fi
+  if [[ ! "$BUCKET" =~ $SAFE_PATTERN_BUCKET ]]; then
+    echo "错误: Bucket 名称包含非法字符"; exit 1
+  fi
+  if [ -n "$STS_TOKEN" ] && [[ ! "$STS_TOKEN" =~ $SAFE_PATTERN_AKSK ]]; then
+    echo "错误: StsToken 包含非法字符"; exit 1
+  fi
+
+  echo "=== 百度智能云 BOS Skill 自动设置 ==="
+  echo ""
+
+  # 1. 安装 Node.js SDK
+  echo "--- 步骤 1: 安装 Node.js SDK ---"
+  if check_node; then
+    if [ ! -f "$BASE_DIR/package.json" ]; then
+      (cd "$BASE_DIR" && npm init -y &>/dev/null)
+      ok "已创建 package.json"
+    fi
+    (cd "$BASE_DIR" && npm install @baiducloud/sdk --no-progress 2>&1 | tail -3)
+    ok "@baiducloud/sdk 安装完成"
+  else
+    warn "Node.js 未安装，跳过 Node.js SDK"
+  fi
+
+  # 2. 检查 bcecmd
+  echo ""
+  echo "--- 步骤 2: 检查 bcecmd ---"
+  if check_bcecmd; then
+    ok "bcecmd 已就绪"
+  else
+    echo "  bcecmd 需要手动安装，参考:"
+    echo "  https://cloud.baidu.com/doc/BOS/s/Ck1rymwdi"
+  fi
+
+  # 3. 持久化凭证到 Skill 数据目录 + 导出环境变量
+  echo ""
+  echo "--- 步骤 3: 持久化凭证 ---"
+
+  local CRED_DIR="$HOME/.config/openclaw/baidu-cloud-bos"
+  local CRED_FILE="$CRED_DIR/credentials.json"
+  mkdir -p "$CRED_DIR"
+
+  # 写入 credentials.json
+  cat > "$CRED_FILE" <<CREDEOF
+{
+  "accessKeyId": "$AK",
+  "secretAccessKey": "$SK",
+  "endpoint": "$ENDPOINT",
+  "bucket": "$BUCKET"$([ -n "$STS_TOKEN" ] && echo ",
+  \"stsToken\": \"$STS_TOKEN\"")
+}
+CREDEOF
+  chmod 600 "$CRED_FILE"
+  ok "凭证已保存到 $CRED_FILE"
+
+  # 同时导出到当前 session
+  export BCE_ACCESS_KEY_ID="$AK"
+  export BCE_SECRET_ACCESS_KEY="$SK"
+  export BCE_BOS_ENDPOINT="$ENDPOINT"
+  export BCE_BOS_BUCKET="$BUCKET"
+  [ -n "$STS_TOKEN" ] && export BCE_STS_TOKEN="$STS_TOKEN"
+  ok "凭证已导出到当前 session"
+
+  # 4. 配置 bcecmd（如果已安装）
+  echo ""
+  echo "--- 步骤 4: 配置 bcecmd ---"
+  if command -v bcecmd &>/dev/null; then
+    local BCECMD_CONF="$HOME/.bcecmd"
+    mkdir -p "$BCECMD_CONF"
+
+    bcecmd --conf-path "$BCECMD_CONF" configure \
+      --access-key "$AK" \
+      --secret-key "$SK" \
+      --domain "$ENDPOINT" 2>/dev/null && \
+      ok "bcecmd 已配置" || \
+      warn "bcecmd 配置失败"
+  else
+    warn "bcecmd 未安装，跳过配置"
+  fi
+
+  # 5. 验证连接
+  echo ""
+  echo "--- 步骤 5: 验证连接 ---"
+
+  local verified=false
+
+  # 优先用 Node.js SDK 验证
+  if command -v node &>/dev/null && node -e "require('@baiducloud/sdk')" &>/dev/null 2>&1; then
+    if (cd "$BASE_DIR" && node scripts/bos_node.mjs list --max-keys 1 2>/dev/null | grep -q '"success": true'); then
+      ok "BOS 连接验证成功（Node.js SDK）"
+      verified=true
+    fi
+  fi
+
+  if [ "$verified" = false ]; then
+    warn "BOS 连接验证失败，请检查凭证和网络"
+  fi
+
+  echo ""
+  echo "=== 设置完成 ==="
+  echo "现在可以使用以下方式操作 BOS："
+  echo "  方式一: node $BASE_DIR/scripts/bos_node.mjs <action>"
+  echo "  方式二: bcecmd bos <command>"
+}
+
+# ========== 主入口 ==========
+
+case "$1" in
+  --check-only)
+    do_check
+    ;;
+  --ak|--sk|--endpoint|--bucket)
+    do_setup "$@"
+    ;;
+  *)
+    echo "百度智能云 BOS Skill 设置工具"
+    echo ""
+    echo "用法:"
+    echo "  $0 --check-only"
+    echo "    仅检查环境状态"
+    echo ""
+    echo "  $0 --ak <AK> --sk <SK> --endpoint <ENDPOINT> --bucket <BUCKET> [--sts-token <TOKEN>]"
+    echo "    自动设置环境（安装依赖 + 配置凭证 + 验证连接）"
+    ;;
+esac


### PR DESCRIPTION
## Summary

- 新增 `baidu-cloud-bos` skill，集成百度智能云对象存储（BOS）
- 支持文件上传/下载/删除/复制、列出文件与 Bucket、获取签名 URL
- 支持图片处理（亮度、对比度、模糊、旋转等）
- 通过 Node.js SDK 脚本（优先）和 bcecmd 命令行双方式管理
- 凭证持久化，新 session 无需重新配置

## Changes

- `SKILL.md` — skill 定义与使用文档
- `scripts/bos_node.mjs` — Node.js SDK 操作脚本
- `scripts/setup.sh` — 环境检查与凭证配置脚本
- `references/api_reference.md` — BOS API 参考文档